### PR TITLE
made it easier to get up and running with a dockerhub image

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ docker build \
   -t newfrontdocker/delta-connect-playground:latest .
 ~~~
 
+> The image doesn't need to be built if you want to use what is in Docker Hub: [newfrontdocker/delta-connect-playground:4.0.0](https://hub.docker.com/r/newfrontdocker/delta-connect-playground/tags)
+
 ## Creating the Docker Network
 ~~~
 docker network create connect
@@ -87,3 +89,12 @@ Connection to localhost port 15002 [tcp/*] succeeded!
 * [Delta Lake](https://delta.io/) - main Delta Lake docs
 * Delta Connect Server: https://mvnrepository.com/artifact/io.delta/delta-connect-server_2.13/4.0.0
 * Delta Connect Client: https://mvnrepository.com/artifact/io.delta/delta-connect-client_2.13/4.0.0
+
+## Release the base container
+~~~
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -t newfrontdocker/delta-connect-playground:4.0.0 \
+  -f Dockerfile \
+  .
+~~~

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   delta-connect-server:
-    image: newfrontdocker/delta-connect-playground:latest
+    image: newfrontdocker/delta-connect-playground:4.0.0
     command: ["server"]
     hostname: delta-connect-server
     container_name: delta-connect-server
@@ -26,7 +26,7 @@ services:
     restart: unless-stopped
 
   delta-connect-playground:
-    image: newfrontdocker/delta-connect-playground:latest
+    image: newfrontdocker/delta-connect-playground:4.0.0
     command: ["client"]
     hostname: delta-connect-playground
     container_name: delta-connect-playground


### PR DESCRIPTION
This update takes into account that the delta-connect-playground image is now up on Docker Hub. 

This removes the need to first build the docker image. You can still do so if you want to, but you don't need to.

Now the environment can get bootstrapped like so:

```
docker compose up --remove-orphans
```